### PR TITLE
thmap_create: Test allocation, not relocation, for null.

### DIFF
--- a/src/t_thmap.c
+++ b/src/t_thmap.c
@@ -17,7 +17,7 @@
 #define	NUM2PTR(x)	((void *)(uintptr_t)(x))
 
 static unsigned		space_allocated = 0;
-static unsigned char	space[42500];
+static unsigned char	space[42500] __aligned(4);
 
 static void
 test_basic(void)
@@ -242,13 +242,13 @@ alloc_test_wrapper(size_t len)
 	uintptr_t p = space_allocated;
 	space_allocated += roundup2(len, sizeof(void *));
 	assert(space_allocated <= sizeof(space));
-	return p;
+	return p + 4;
 }
 
 static void
 free_test_wrapper(uintptr_t addr, size_t len)
 {
-	assert(addr < sizeof(space));
+	assert(addr - 4 < sizeof(space));
 	assert(len < sizeof(space));
 
 	space_allocated -= roundup2(len, sizeof(void *));
@@ -263,7 +263,7 @@ static const thmap_ops_t thmap_test_ops = {
 static void
 test_mem(void)
 {
-	uintptr_t baseptr = (uintptr_t)(void *)space;
+	uintptr_t baseptr = (uintptr_t)(void *)space - 4;
 	const unsigned nitems = 512;
 	thmap_t *hmap;
 	void *ret;

--- a/src/thmap.c
+++ b/src/thmap.c
@@ -894,11 +894,11 @@ thmap_create(uintptr_t baseptr, const thmap_ops_t *ops, unsigned flags)
 	if ((thmap->flags & THMAP_SETROOT) == 0) {
 		/* Allocate the root level. */
 		root = thmap->ops->alloc(THMAP_ROOT_LEN);
-		thmap->root = THMAP_GETPTR(thmap, root);
-		if (!thmap->root) {
+		if (!root) {
 			free(thmap);
 			return NULL;
 		}
+		thmap->root = THMAP_GETPTR(thmap, root);
 		memset(thmap->root, 0, THMAP_ROOT_LEN);
 		atomic_thread_fence(memory_order_release); /* XXX */
 	}


### PR DESCRIPTION
Adapt test so it never returns zero on success.

fix https://github.com/rmind/thmap/issues/13